### PR TITLE
Ignore HTML Comments in Markdown

### DIFF
--- a/src/IO/Markdown/Internal.hs
+++ b/src/IO/Markdown/Internal.hs
@@ -58,6 +58,7 @@ matches = [
       , (descriptionOutput, addDescription)
       , (dueOutput, addDue)
       , (subtaskOutput, addSubItem)
+      , (const "<!--", const id)
     ]
 
 start :: Config -> (Lists, [Int]) -> (Text, Int) -> (Lists, [Int])


### PR DESCRIPTION
I'm not 100% sure how you'd like to handle these, but it seems like all markdown spec (including [daringfireball](https://daringfireball.net/projects/markdown), [CommonMark](https://spec.commonmark.org/0.28/) and [GitHub-flavored Markdown](https://github.github.com/gfm/)) allow for HTML embedded comments. They also seem to be the only way to comment in markdown.

Here's a quick fix I came up with on my end to allow single-line comments. It fails for multi-line comments and the event of prefixed characters, but it is the most minimal change I could quickly prototype that doesn't interfer with parse handling exception (so error'd indexes remain unchanged).

Let me know if you want me to update this at all! Long-term you may want to use [cmark][cm] or [cmark-gfm][gfm], but the code was clean enough to follow along -- kudos!

PS: In regards to the parental leave, I am guessing congratulations are also in order!

[cm]:https://hackage.haskell.org/package/cmark
[gfm]:https://hackage.haskell.org/package/cmark-gfm