### PR TITLE
Fix a typo

### DIFF
--- a/docs/html/_config.yml
+++ b/docs/html/_config.yml
@@ -1,6 +1,6 @@
 # Setup
 title:        taskell
-tagline:      Command-line Kanban board/task managment
+tagline:      Command-line Kanban board/task management
 baseurl:      ""
 locale:       "en"
 version:      1.4.3


### PR DESCRIPTION
The misspelled word was displayed at the [homepage](https://taskell.app/). Whoops! 😊