### PR TITLE
Scarf install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ There are usually bottles (binaries) available. If these are not available for y
 
 Not officially supported, but try running `sudo dnf install ncurses-compat-libs` then download and run the binary as described below. If that doesn't work you may need to build from scratch ([Cabal](#cabal)/[Stack](#stack)).
 
+### Scarf
+
+Taskell is available on [Scarf](https://scarf.sh/package/scarf/taskell).
+
+```bash
+scarf install taskell
+```
+
 ### Binaries
 
 [A binary is available for Mac and Debian/Ubuntu](https://github.com/smallhadroncollider/taskell/releases). Download it and copy it to a directory in your `$PATH` (e.g. `/usr/local/bin` or `/usr/bin`).


### PR DESCRIPTION
Hello! This README change adds install instructions for the [Scarf](https://scarf.sh) package manager (disclaimer: I am the author of Scarf, currently early on in building up the ecosystem). I am happy to maintain the taskell package, and can transfer ownership to you at any time if you're interested in any of the tooling Scarf provides for package owners.