### PR TITLE
Include roadmap.md in source distribution

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,7 @@ extra-source-files:
 - README.md
 - templates/*
 - test/Taskell/IO/data/*.json
+- test/Taskell/IO/data/*.md
 - test/Taskell/IO/Keyboard/data/bindings.ini
 
 default-extensions:


### PR DESCRIPTION
Fixes the following build error when compiling the test suite from a hackage source checkout:

```
[17 of 21] Compiling Taskell.IO.Markdown.ParserTest ( test/Taskell/IO/Markdown/ParserTest.hs, dist/build/taskell-test/taskell-test-tmp/Taskell/IO/Markdown/ParserTest.dyn_o )

test/Taskell/IO/Markdown/ParserTest.hs:33:19: error:
    • Exception when trying to run compile-time code:
        test/Taskell/IO/data/roadmap.md: openBinaryFile: does not exist (No such file or directory)
      Code: embedFile "test/Taskell/IO/data/roadmap.md"
    • In the untyped splice:
        $(embedFile "test/Taskell/IO/data/roadmap.md")
   |
33 | file = decodeUtf8 $(embedFile "test/Taskell/IO/data/roadmap.md")
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

- [x] Have you [followed the contributing guidelines](https://github.com/smallhadroncollider/taskell/blob/master/CONTRIBUTING.md)?
- [x] Are you working/merging into `develop`?
- [x] Do all tests pass?
