### PR TITLE
Refactor command-line arguments parsing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -75,6 +75,7 @@ library:
   - http-types
   - lens
   - mtl
+  - optparse-applicative
   - template-haskell
   - text
   - time

--- a/src/Taskell/Config.hs
+++ b/src/Taskell/Config.hs
@@ -17,6 +17,3 @@ trelloUsage = decodeUtf8 $(embedFile "templates/trello-token.txt")
 
 githubUsage :: Text
 githubUsage = decodeUtf8 $(embedFile "templates/github-token.txt")
-
-usage :: Text
-usage = decodeUtf8 $(embedFile "templates/usage.txt")

--- a/templates/usage.txt
+++ b/templates/usage.txt
@@ -1,9 +1,0 @@
-Usage: taskell ([options] | [-i | -t <trello-board-id> | -g [orgs/<org> | repos/<username>/<repo>]] file)
-
-Options:
-
--h                                               Help
--v                                               Version number
--i file                                          Display information about a file
--t <trello-board-id> file                        Create a new taskell file from the given Trello board ID
--g [orgs/<org> | repos/<username>/<repo>] file   Create a new taskell file from the given GitHub identifier


### PR DESCRIPTION
- [x] Have you [followed the contributing guidelines](https://github.com/smallhadroncollider/taskell/blob/master/CONTRIBUTING.md)?
- [x] Are you working/merging into `develop`?
- [x] Do all tests pass?

If appropriate:

- [ ] Have you added new tests for additional functionality?

     *Technically there are no additional functionality. I was aiming to not change any of the previous behavior (except fixing visible issue like `--help` is being interpreted as a file name). If it was parsing some pure data technically I can come up with a test but it would change the implementation quiet significantly. I can do this in a separate MR if you want me to.*

---

Use “optparse-applicative” library. The parser is also the spec. The same code describes the arguments and parses them. Usage info is generated automatically from the parser. `--help` and `-h` are also handled automatically as a generic thing. No need to describe them separately.

Initially I’ve tried to call `taskell --help` and got this in response:

> Create /home/wenzel/dev/haskell/taskell/--help? (Y/n):

Which confused me. I went to look at the code to see how the arguments parsing can be improved.

Usually you parse some pure data type out from command-line arguments. And then you decide what to do with that pure data. But I parsed monadic actions directly in order to keep this implementation close to the previous one.

An example of the auto-generated usage info:

``` console
$ result/bin/taskell --help
Taskell - A CLI kanban board/task manager

Usage: taskell [file | (-v|--version) | (-t|--trello <trello-board-id>) file |
                 (-g|--github [orgs/<org> | repos/<username>/<repo>]) file |
                 [-i|--info] file]

Available options:
  -h,--help                Show this help text
  -v,--version             Show version number
  -t,--trello <trello-board-id>
                           Create a new taskell file from the given Trello board
                           ID
  -g,--github [orgs/<org> | repos/<username>/<repo>]
                           Create a new taskell file from the given GitHub
                           identifier
  -i,--info                Display information about a file
```